### PR TITLE
Don't show a delayed Tipsy if underlying element is removed

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -34,6 +34,11 @@
     
     Tipsy.prototype = {
         show: function() {
+            // if element is not in the DOM then don't show the Tipsy and return early
+            if (!isElementInDOM(this.$element[0])) {
+                return;
+            }
+
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();


### PR DESCRIPTION
Currently if Tipsy has a `delayIn`, and the element is removed
from the DOM before the Tipsy displays, then the Tipsy will still
appear as an orphan at the top left of the page.  This change adds
an additional check to ensure that the element is in the DOM before
showing the Tipsy.

(Atlassian AUI ref: [AUI-2607](https://ecosystem.atlassian.net/browse/AUI-2607))
