### PR TITLE
AUI-3828: Fix tooltip position for SVG elements

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -70,8 +70,8 @@
                 }
 
                 var pos = $.extend({}, this.$element.offset(), {
-                    width: this.$element[0].offsetWidth,
-                    height: this.$element[0].offsetHeight
+                    width: this.$element[0].getBoundingClientRect().width,
+                    height: this.$element[0].getBoundingClientRect().height
                 });
                 
                 var actualWidth = $tip[0].offsetWidth,


### PR DESCRIPTION
This introduces a fix for the bug outlined in [AUI-3828](https://ecosystem.atlassian.net/browse/AUI-3828). It is similar to [a still-open PR on tipsy](https://github.com/jaz303/tipsy/pull/147), except that we use `getBoundingClientRect` here.