### PR TITLE
AUI-3830 Add destroy-method to tipsy

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -119,8 +119,6 @@
             }
         },
 
-        // AUI-3830 https://ecosystem.atlassian.net/browse/AUI-3830
-        // We need to be able to remove tipsy from an element
         destroy: function(){
           $.removeData(this.$element.get(0));
 

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -118,6 +118,23 @@
                 }
             }
         },
+
+        // AUI-3830 https://ecosystem.atlassian.net/browse/AUI-3830
+        // We need to be able to remove tipsy from an element
+        destroy: function(){
+          $.removeData(this.$element.get(0));
+
+          this.unbindHandlers();
+          this.hide();
+        },
+
+        unbindHandlers: function() {
+          if(this.options.live){
+            $(this.$element.context).off('.tipsy');
+          } else {
+            this.$element.unbind('.tipsy');
+          }
+        },
         
         hide: function() {
             if (this.options.fade) {

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -120,18 +120,18 @@
         },
 
         destroy: function(){
-          $.removeData(this.$element.get(0));
+            this.$element.removeData('tipsy');
 
-          this.unbindHandlers();
-          this.hide();
+            this.unbindHandlers();
+            this.hide();
         },
 
         unbindHandlers: function() {
-          if(this.options.live){
-            $(this.$element.context).off('.tipsy');
-          } else {
-            this.$element.unbind('.tipsy');
-          }
+            if(this.options.live){
+                $(this.$element.context).off('.tipsy');
+            } else {
+                this.$element.unbind('.tipsy');
+            }
         },
         
         hide: function() {


### PR DESCRIPTION
When using tipsy with React, we need a way to destroy generated DOM in order to free up memory.