### PR TITLE
jQuery 3 compatibility

### DIFF
--- a/docs/src/index.html.erb
+++ b/docs/src/index.html.erb
@@ -287,12 +287,12 @@ an anchor tag's title attribute.</p>
   </div>
   
   <script type='text/javascript'>
-    $('a.live-tipsy').tipsy({live: true});
+    $(document).tipsy({live: 'a.live-tipsy'});
   </script>
   
   <div class='caption'>Code for live events:</div>
   <div class='code'><pre>&lt;script type=&#x27;text/javascript&#x27;&gt;
-  $(&#x27;a.live-tipsy&#x27;).tipsy({live: true});
+  $(document).tipsy({live: &#x27;a.live-tipsy&#x27;});
 &lt;/script&gt;</pre></div>
   
   <!-- Options -->

--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -16,10 +16,8 @@
     };
     
     function isElementInDOM(ele) {
-      while (ele = ele.parentNode) {
-        if (ele == document) return true;
-      }
-      return false;
+      var el = ele && ele.jquery ? ele.get(0) : ele;
+      return $.contains(document.documentElement, el);
     };
 
     var tipsyIDcounter = 0;
@@ -38,7 +36,7 @@
     Tipsy.prototype = {
         show: function() {
             // if element is not in the DOM then don't show the Tipsy and return early
-            if (!isElementInDOM(this.$element[0])) {
+            if (!isElementInDOM(this.$element)) {
                 return;
             }
 
@@ -248,17 +246,25 @@
                 tipsy.show();
             } else {
                 tipsy.fixTitle();
-                setTimeout(function() { if (tipsy.hoverState == 'in') tipsy.show(); }, options.delayIn);
+                setTimeout(function() {
+                    if (tipsy.hoverState == 'in' && isElementInDOM(tipsy.$element)) {
+                        tipsy.show();
+                    }
+                }, options.delayIn);
             }
         };
-        
+
         function leave() {
             var tipsy = get(this);
             tipsy.hoverState = 'out';
             if (options.delayOut == 0) {
                 tipsy.hide();
             } else {
-                setTimeout(function() { if (tipsy.hoverState == 'out' && !tipsy.hoverTooltip) tipsy.hide(); }, options.delayOut);
+                setTimeout(function() {
+                    if (tipsy.hoverState == 'out' && !tipsy.hoverTooltip) {
+                        tipsy.hide();
+                    }
+                }, options.delayOut);
             }
         };
         


### PR DESCRIPTION
This makes Tipsy compatible with jQuery versions 1.9 through 3.3.1.

It's technically a backwards-incompatible API change -- the `live` option must be a string instead of a boolean -- so semver would dictate this is a major version.