### PR TITLE
Added option for tooltip to use element as parent instead of Body

### DIFF
--- a/src/javascripts/jquery.tipsy.js
+++ b/src/javascripts/jquery.tipsy.js
@@ -40,6 +40,7 @@
                 return;
             }
 
+            var parent = this.options.appendToElement ? this.$element[0] : document.body;
             var title = this.getTitle();
             if (title && this.enabled) {
                 var $tip = this.tip();
@@ -55,7 +56,7 @@
                         visibility: "hidden",
                         display: "block"
                     })
-                    .appendTo(document.body);
+                    .appendTo(parent);
 
                 var that = this;
                 function tipOver() {
@@ -83,10 +84,19 @@
                     );
                 }
 
-                var pos = $.extend({}, this.$element.offset(), {
+                var pos = {
                     width: this.$element[0].getBoundingClientRect().width,
                     height: this.$element[0].getBoundingClientRect().height
-                });
+                };
+
+                if (this.options.appendToElement) {
+                    // starting left and top are 0 if appending to element
+                    pos = $.extend({}, pos, {left: 0, top: 0})
+                }
+                else {
+                    // otherwise, calculate the position of the element to show the tooltip in body
+                    pos = $.extend({}, pos, this.$element.offset());
+                }
 
                 var tipCss = {};
                 var actualWidth = $tip[0].offsetWidth,


### PR DESCRIPTION
With this option, the tooltip can now be appended to the element itself, allowing it to maintain the position if the element moves while hovering.

Example: a sticky button with a tooltip
![tooltip-bug-test](https://user-images.githubusercontent.com/722261/51353438-c296e980-1b04-11e9-815b-155f2e71edf1.gif)

With this fix:
![tooltip-bug-fix](https://user-images.githubusercontent.com/722261/51353453-cc205180-1b04-11e9-8c37-6262debecbef.gif)

